### PR TITLE
allow more comment notations

### DIFF
--- a/src/review-to-ast.js
+++ b/src/review-to-ast.js
@@ -98,7 +98,7 @@ function doParse(text) {
     }
 
     // ignore comment
-    if (currentLine.startsWith('#@#')) {
+    if (currentLine.startsWith('#@')) {
       return;
     }
 

--- a/test/ReVIEWProcessor-test.js
+++ b/test/ReVIEWProcessor-test.js
@@ -59,7 +59,7 @@ describe("ReVIEWProcessor-test", function () {
                              ['Paragraph', 'Break', 'Paragraph']);
         });
         it("#@warn should be ignored", function () {
-            let result = parse(`test\nparagraph\n\n#@warn(TODO: should be fixed)\n\nanother paragraph`);
+            let result = parse(`test\nparagraph\n\n#@warn(TODO: should be fixed)\nanother paragraph`);
             assert.deepEqual(result.children.map(node => node.type),
                              ['Paragraph', 'Break', 'Paragraph']);
         });

--- a/test/ReVIEWProcessor-test.js
+++ b/test/ReVIEWProcessor-test.js
@@ -55,11 +55,13 @@ describe("ReVIEWProcessor-test", function () {
         it("#@# should be ignored", function () {
             let result = parse(`#@# ???\ntest\nparagraph\n#@# !!!\n\nanother paragraph`);
             assert.equal(result.children.length, 3);
+            assert(!result.children[0].raw.includes('???'));
             assert.deepEqual(result.children.map(node => node.type),
                              ['Paragraph', 'Break', 'Paragraph']);
         });
         it("#@warn should be ignored", function () {
             let result = parse(`test\nparagraph\n\n#@warn(TODO: should be fixed)\nanother paragraph`);
+            assert(!result.children[2].raw.includes('TODO'));
             assert.deepEqual(result.children.map(node => node.type),
                              ['Paragraph', 'Break', 'Paragraph']);
         });

--- a/test/ReVIEWProcessor-test.js
+++ b/test/ReVIEWProcessor-test.js
@@ -52,6 +52,17 @@ describe("ReVIEWProcessor-test", function () {
                 assert.equal(code.type, "Code");
             });
         });
+        it("#@# should be ignored", function () {
+            let result = parse(`#@# ???\ntest\nparagraph\n#@# !!!\n\nanother paragraph`);
+            assert.equal(result.children.length, 3);
+            assert.deepEqual(result.children.map(node => node.type),
+                             ['Paragraph', 'Break', 'Paragraph']);
+        });
+        it("#@warn should be ignored", function () {
+            let result = parse(`test\nparagraph\n\n#@warn(TODO: should be fixed)\n\nanother paragraph`);
+            assert.deepEqual(result.children.map(node => node.type),
+                             ['Paragraph', 'Break', 'Paragraph']);
+        });
     });
     describe("ReVIEWPlugin", function () {
         let textlint;


### PR DESCRIPTION
Re:VIEW's comments are not only `#@#`, but also `#@warn(...)` or other markups started with `#@`.