### PR TITLE
fix to generate Break node

### DIFF
--- a/test/ReVIEWProcessor-test.js
+++ b/test/ReVIEWProcessor-test.js
@@ -26,7 +26,7 @@ describe("ReVIEWProcessor-test", function () {
               assert.equal(str.type, 'Str');
             });
         });
-        it("separated lines should form each Paragraph splited by Break", function () {
+        it("separated lines should form each Paragraph", function () {
             var result = parse(`test\nparagraph\n\nanother paragraph`);
             assert.equal(result.children.length, 2);
             assert.deepEqual(result.children.map(node => node.type),
@@ -57,6 +57,7 @@ describe("ReVIEWProcessor-test", function () {
             let script = result.children[0];
             assert(script.children[0].raw.startsWith("first line"));
             assert.equal(script.children[1].type, "Break");
+            assert.equal(script.children[1].raw, "@<br>{}");
             assert(script.children[2].raw.startsWith("second line"));
         });
         it("#@# should be ignored", function () {

--- a/test/ReVIEWProcessor-test.js
+++ b/test/ReVIEWProcessor-test.js
@@ -28,9 +28,9 @@ describe("ReVIEWProcessor-test", function () {
         });
         it("separated lines should form each Paragraph splited by Break", function () {
             var result = parse(`test\nparagraph\n\nanother paragraph`);
-            assert.equal(result.children.length, 3);
+            assert.equal(result.children.length, 2);
             assert.deepEqual(result.children.map(node => node.type),
-                             ['Paragraph', 'Break', 'Paragraph']);
+                             ['Paragraph', 'Paragraph']);
         });
         it("equal signs should be headings", function () {
             var result = parse(`={ch01} Test\n\n== Headings`);
@@ -52,18 +52,25 @@ describe("ReVIEWProcessor-test", function () {
                 assert.equal(code.type, "Code");
             });
         });
+        it("@<br>{} should be Break", function () {
+            let result = parse(`first line and@<br>{}second line are same pagaraph.\n`);
+            let script = result.children[0];
+            assert(script.children[0].raw.startsWith("first line"));
+            assert.equal(script.children[1].type, "Break");
+            assert(script.children[2].raw.startsWith("second line"));
+        });
         it("#@# should be ignored", function () {
             let result = parse(`#@# ???\ntest\nparagraph\n#@# !!!\n\nanother paragraph`);
-            assert.equal(result.children.length, 3);
+            assert.equal(result.children.length, 2);
             assert(!result.children[0].raw.includes('???'));
             assert.deepEqual(result.children.map(node => node.type),
-                             ['Paragraph', 'Break', 'Paragraph']);
+                             ['Paragraph', 'Paragraph']);
         });
         it("#@warn should be ignored", function () {
             let result = parse(`test\nparagraph\n\n#@warn(TODO: should be fixed)\nanother paragraph`);
-            assert(!result.children[2].raw.includes('TODO'));
+            assert(!result.children[1].raw.includes('TODO'));
             assert.deepEqual(result.children.map(node => node.type),
-                             ['Paragraph', 'Break', 'Paragraph']);
+                             ['Paragraph', 'Paragraph']);
         });
     });
     describe("ReVIEWPlugin", function () {


### PR DESCRIPTION
Re:VIEW has line break notation `@<br>{}`.
It should be Break and `\n` should not be Break.

### Implementation

I added a function `flushParagraph` and temporary variable `currentParagraph`.
Original implementation uses the last element of variable `result` for status management.
But `Paragraph`s can be continued without a break (I confirmed it with markdown-to-ast).
In such case, `result` cannot be used as status check.  If we have only `result`, we cannot
distinguish whether current line is in new paragraph or continuation of previous paragraph.
So I introduced flushing function and status variable.
