### PR TITLE
Add Compliance test for textlint

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "mocha": "^2.3.3",
     "power-assert": "^1.1.0",
     "textlint": "^4.2.1",
+    "textlint-ast-test": "^1.1.2",
     "textlint-rule-no-todo": "^1.0.3"
   },
   "dependencies": {

--- a/src/review-to-ast.js
+++ b/src/review-to-ast.js
@@ -60,6 +60,7 @@ function doParse(text) {
 
   var ast = {
     type: Syntax.Document,
+    raw: text,
     range: [0, startIndex],
     loc: {
       start: {

--- a/test/compliance-test.js
+++ b/test/compliance-test.js
@@ -1,0 +1,17 @@
+"use strict";
+import {test,isTxtAST} from "textlint-ast-test";
+import {parse} from "../src/review-to-ast";
+import assert from "power-assert";
+import fs from "fs";
+import path from "path";
+describe("compliance", function () {
+    context("when use fixture", function () {
+        it("should pass compliance test", function () {
+            var fixturePath = path.join(__dirname, "fixtures/test.re");
+            var content = fs.readFileSync(fixturePath, "utf-8");
+            var AST = parse(content);
+            test(AST);
+            assert(isTxtAST(AST));
+        });
+    })
+});

--- a/test/compliance-test.js
+++ b/test/compliance-test.js
@@ -1,5 +1,5 @@
 "use strict";
-import {test,isTxtAST} from "textlint-ast-test";
+import {isTxtAST} from "textlint-ast-test";
 import {parse} from "../src/review-to-ast";
 import assert from "power-assert";
 import fs from "fs";
@@ -10,7 +10,6 @@ describe("compliance", function () {
             var fixturePath = path.join(__dirname, "fixtures/test.re");
             var content = fs.readFileSync(fixturePath, "utf-8");
             var AST = parse(content);
-            test(AST);
             assert(isTxtAST(AST));
         });
     })


### PR DESCRIPTION
Hi, I'v added compliance-test for textlint.

[textlint/textlint-ast-test](https://github.com/textlint/textlint-ast-test "textlint/textlint-ast-test") is a test module that validate the AST.

So, I'v found missing `raw` of `Document` node and fixed it.

I'v re-defined `TxtNode` in detail and update document on textlint.
Please see https://github.com/textlint/textlint/pull/170 for details.
