### PR TITLE
Parse table cell as a ListItem

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ textlint ch01.re
 
 ## Current Limitations
 
-* All the blocks, e.g. `//list[]{ ... //}` or `//image[][]`, are ignored. So they do not appear in the resulting AST.
+* All the blocks except for table, e.g. `//list[]{ ... //}` or `//image[][]`, are ignored. So they do not appear in the resulting AST.
 
 ## Contributing
 

--- a/src/review-to-ast.js
+++ b/src/review-to-ast.js
@@ -181,8 +181,15 @@ function parseTableContent(text, startIndex, lineNumber) {
   const cellRegex = /[^\t]+/g;
   var match;
   while (match = cellRegex.exec(text)) {
-    const startColumn = match.index;
-    const cellContent = match[0];
+    let startColumn = match.index;
+    let cellContent = match[0];
+    if (cellContent.startsWith('.')) {
+      cellContent = cellContent.substr(1);
+      startColumn += 1;
+    }
+    if (cellContent == '') {
+      continue;
+    }
     const cellNode = createNode('ListItem', cellContent, startIndex + startColumn,
                                 lineNumber, startColumn);
     cellNode.children = parseText(cellContent, startIndex + startColumn, lineNumber, startColumn);

--- a/src/review-to-ast.js
+++ b/src/review-to-ast.js
@@ -77,23 +77,26 @@ function doParse(text) {
 
   return ast;
 
-  var isInBlock = false;
+  var currentBlock = null;
   var currentParagraph = null;
 
   function parseLine(result, currentLine, lineNumber, startIndex) {
     var currentText = currentLine.replace(/\r?\n$/, ''); // without line endings
 
     // ignore block
-    if (isInBlock) {
+    if (isInBlock()) {
       if (currentLine.startsWith('//}')) {
-        isInBlock = false;
+        currentBlock = null;
+      } else if (currentBlock == 'table') {
+        Array.prototype.push.apply(result, parseTableContent(currentText, startIndex, lineNumber));
       }
       return;
     }
 
-    if (currentLine.search(/^\/\/\w+.*?\{$/m) >= 0) {
+    let match = currentLine.match(/^\/\/(\w+).*?\{$/m);
+    if (match) {
       flushParagraph(result);
-      isInBlock = true;
+      currentBlock = match[1];
       return;
     }
 
@@ -139,6 +142,10 @@ function doParse(text) {
     }
     currentParagraph = null;
   }
+
+  function isInBlock() {
+    return currentBlock != null;
+  }
 }
 
 /**
@@ -159,15 +166,43 @@ function parseHeading(text, startIndex, lineNumber) {
 }
 
 /**
- * parse inline tags and StrNodes from line.
+ * parse line in a table.
  * @param {string} text - Text of the line
  * @param {number} startIndex - Global start index of the line
  * @param {number} lineNumber - Line number of the line
  * @return {[TxtNode]} TxtNodes in the line
  */
-function parseText(text, startIndex, lineNumber) {
+function parseTableContent(text, startIndex, lineNumber) {
+  if (text.match(/^-+$/)) {
+    return [];  // Ignore horizontal line
+  }
+
+  const nodes = [];
+  const cellRegex = /[^\t]+/g;
+  var match;
+  while (match = cellRegex.exec(text)) {
+    const startColumn = match.index;
+    const cellContent = match[0];
+    const cellNode = createNode('ListItem', cellContent, startIndex + startColumn,
+                                lineNumber, startColumn);
+    cellNode.children = parseText(cellContent, startIndex + startColumn, lineNumber, startColumn);
+    nodes.push(cellNode);
+  }
+
+  return nodes;
+}
+
+/**
+ * parse inline tags and StrNodes from line.
+ * @param {string} text - Text of the line
+ * @param {number} startIndex - Global start index of the line
+ * @param {number} lineNumber - Line number of the line
+ * @param {number} [startColumn=0] - Start column in the line
+ * @return {[TxtNode]} TxtNodes in the line
+ */
+function parseText(text, startIndex, lineNumber, startColumn) {
+  startColumn = startColumn || 0;
   var nodes = [];
-  var startColumn = 0;
   var match;
   // TODO: Support escape character \} in { }
   while (match = text.match(/@<(\w+)>\{(.*?)\}/)) {

--- a/src/review-to-ast.js
+++ b/src/review-to-ast.js
@@ -83,6 +83,11 @@ function doParse(text) {
   function parseLine(result, currentLine, lineNumber, startIndex) {
     var currentText = currentLine.replace(/\r?\n$/, ''); // without line endings
 
+    // ignore comment
+    if (currentLine.startsWith('#@')) {
+      return;
+    }
+
     // ignore block
     if (isInBlock()) {
       if (currentLine.startsWith('//}')) {
@@ -103,11 +108,6 @@ function doParse(text) {
     // ignore images or something
     if (currentLine.search(/^\/\/\w+/) >= 0) {
       flushParagraph(result);
-      return;
-    }
-
-    // ignore comment
-    if (currentLine.startsWith('#@')) {
       return;
     }
 

--- a/test/ReVIEWProcessor-test.js
+++ b/test/ReVIEWProcessor-test.js
@@ -95,6 +95,26 @@ second line`);
             assert(result.children[0].raw == 'first line');
             assert(result.children[1].raw == 'second line');
         });
+        it("should parse table cell as ListItem", function () {
+            let result = parse(`
+//table[][]{
+Name\t\tComment
+-------------------------------------------------------------
+PATH\t\tDirectories where commands exist
+TERM\t\tTerminal. ex: linux, kterm, vt100
+//}`);
+            assert(result.children.length == 6);
+            result.children.forEach(function (node) {
+                assert(node.type == 'ListItem');
+                assert(node.children.length == 1);
+                assert(node.children[0].type == 'Str');
+            });
+            assert.deepEqual(result.children.map(node => node.children[0].raw), [
+                'Name', 'Comment',
+                'PATH', 'Directories where commands exist',
+                'TERM', 'Terminal. ex: linux, kterm, vt100'
+            ]);
+        });
     });
     describe("ReVIEWPlugin", function () {
         let textlint;

--- a/test/ReVIEWProcessor-test.js
+++ b/test/ReVIEWProcessor-test.js
@@ -115,6 +115,15 @@ TERM\t\tTerminal. ex: linux, kterm, vt100
                 'TERM', 'Terminal. ex: linux, kterm, vt100'
             ]);
         });
+        it("should parse inline markups in a table cell", function () {
+            let result = parse(`
+//table[][]{
+Name\tValue
+-----------
+@<code>{x}\t1
+//}`);
+            assert(result.children[2].children[0].type == 'Code');
+        });
         it("should ignore starting . in a table cell", function () {
             let result = parse(`
 //table[][]{

--- a/test/ReVIEWProcessor-test.js
+++ b/test/ReVIEWProcessor-test.js
@@ -123,6 +123,13 @@ TERM\t\tTerminal. ex: linux, kterm, vt100
             assert.deepEqual(result.children.map(node => node.children[0].raw),
                              ['.gitignore']);
         });
+        it("should ignore comments in a table", function () {
+            let result = parse(`
+//table[][]{
+#@# comment in a table
+//}`);
+            assert(result.children.length == 0);
+        });
     });
     describe("ReVIEWPlugin", function () {
         let textlint;

--- a/test/ReVIEWProcessor-test.js
+++ b/test/ReVIEWProcessor-test.js
@@ -115,6 +115,14 @@ TERM\t\tTerminal. ex: linux, kterm, vt100
                 'TERM', 'Terminal. ex: linux, kterm, vt100'
             ]);
         });
+        it("should ignore starting . in a table cell", function () {
+            let result = parse(`
+//table[][]{
+.\t..gitignore\t
+//}`);
+            assert.deepEqual(result.children.map(node => node.children[0].raw),
+                             ['.gitignore']);
+        });
     });
     describe("ReVIEWPlugin", function () {
         let textlint;


### PR DESCRIPTION
Currently there is no standard tag to represent a table cell.
https://github.com/textlint/textlint/blob/master/src/shared/type/TextLintNodeType.js

I believe that treating a table cell as a ListItem is reasonable, because some rule, e.g. [no-mix-dearu-desumasu](https://github.com/azu/textlint-rule-no-mix-dearu-desumasu), behave differently between normal Str and ListItem.