### PR TITLE
Support @<kw>{}'s alt attribute

### DIFF
--- a/src/inline-parsers.js
+++ b/src/inline-parsers.js
@@ -22,7 +22,6 @@ export function parseLine(line) {
 
 const InlineParsers = {
   // text tags
-  kw:      inlineTextTagParser(Syntax.Keyword),
   bou:     inlineTextTagParser(Syntax.Bouten),
   ami:     inlineTextTagParser(Syntax.Amikake),
   u:       inlineTextTagParser(Syntax.Underline),
@@ -36,6 +35,7 @@ const InlineParsers = {
   tcy:     inlineTextTagParser(Syntax.TateChuYoko),
 
   // partially text tags
+  kw:      parseKeywordTag,
   ruby:    parseRubyTag,
   href:    parseHrefTag,
 
@@ -116,6 +116,27 @@ function parseInlineTextTag(type, tag, context) {
   const strContext = offsetContext(context, tag.content.index);
   const strNode = createStrNode(tag.content.raw, strContext);
   node.children = [strNode];
+  return node;
+}
+
+/**
+ * parse @<kw>{} tag.
+ * @param {Tag} tag - tag to parse
+ * @param {Context} context - context of the node
+ * @return {TxtNode}
+ */
+function parseKeywordTag(tag, context) {
+  const node = createInlineNode(Syntax.Keyword, tag.fullText, context);
+
+  const pieces = tag.content.raw.split(/\s*,\s*/, 2);
+  const word = pieces[0];
+  if (pieces.length === 2) {
+    node.alt = pieces[1];
+  }
+
+  const strNode = createStrNode(word, context);
+  node.children = [strNode];
+
   return node;
 }
 

--- a/test/inline-parsers-test.js
+++ b/test/inline-parsers-test.js
@@ -147,5 +147,33 @@ describe('inline-parsers', function () {
       assert(comment.raw === '@<comment>{TODO: fix this}');
       assert(comment.value === 'TODO: fix this');
     });
+
+    it('should parse kw tag as a Strong node', function () {
+      const nodes = parseText(`@<kw>{SMTP} is a protocol for email.`, context);
+      assert(nodes.length === 2);
+      assert.deepEqual(nodes.map(node => node.type),
+                       ['Strong', 'Str']);
+      const kw = nodes[0];
+      assert(kw.raw === '@<kw>{SMTP}');
+      assert(kw.alt === undefined);
+      assert(kw.children.length === 1);
+      const str = kw.children[0];
+      assert(str.type === 'Str');
+      assert(str.raw === 'SMTP');
+    });
+
+    it('should parse kw tag with alt attribute', function () {
+      const nodes = parseText(`@<kw>{SMTP, Simple Mail Transfer Protocol} is a protocol for email.`, context);
+      assert(nodes.length === 2);
+      assert.deepEqual(nodes.map(node => node.type),
+                       ['Strong', 'Str']);
+      const kw = nodes[0];
+      assert(kw.raw === '@<kw>{SMTP, Simple Mail Transfer Protocol}');
+      assert(kw.alt === 'Simple Mail Transfer Protocol');
+      assert(kw.children.length === 1);
+      const str = kw.children[0];
+      assert(str.type === 'Str');
+      assert(str.raw === 'SMTP');
+    });
   });
 });

--- a/test/review-to-ast-test.js
+++ b/test/review-to-ast-test.js
@@ -441,6 +441,10 @@ Foo
       const caption = image.children[0];
       assert(caption.type === 'Caption');
       assert(caption.raw === 'a brief history of UNIX-like OS');
+      assert(caption.children.length == 1);
+      const str = caption.children[0];
+      assert(str.type === 'Str');
+      assert(str.raw === 'a brief history of UNIX-like OS');
     });
 
     it('should parse multi-line image block with caption', function () {
@@ -456,6 +460,10 @@ System V
       const caption = image.children[0];
       assert(caption.type === 'Caption');
       assert(caption.raw === 'a brief history of UNIX-like OS');
+      assert(caption.children.length == 1);
+      const str = caption.children[0];
+      assert(str.type === 'Str');
+      assert(str.raw === 'a brief history of UNIX-like OS');
     });
 
     it('should parse lead block as block having paragraphs', function () {


### PR DESCRIPTION
Now the second argument of `@<kw>{}` tag is now parsed as alt attribute of Strong node.

e.g. `@<kw>{SMTP, Simple Mail Transfer Protocol}` is now parsed as:

* `SMTP` corresponds to a Str node, which is a child of the Strong node.
* `Simple Mail Transfer Protocol` corresponds to an alt attribute of the Strong node.