### PR TITLE
Update textlint version to 11.4

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,19 @@
+{
+  "presets": [
+    "env"
+  ],
+  "env": {
+    "development": {
+      "presets": [
+        "power-assert"
+      ]
+    }
+  },
+  "plugins": [
+    "babel-plugin-espower"
+  ],
+  "ignore":[
+    "lib",
+    "node_modules"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "babel-plugin-espower": "^3.0.1",
     "mocha": "^6.1.4",
     "power-assert": "^1.6.1",
-    "@textlint/kernel": "^3.1.6",
-    "textlint": "^11.2.6",
+    "@textlint/kernel": "^3.1.9",
+    "textlint": "^11.4.0",
     "textlint-filter-rule-comments": "^1.2.2",
     "textlint-rule-no-todo": "^2.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -35,18 +35,21 @@
     "lint"
   ],
   "devDependencies": {
-    "babel": "^5.8.29",
-    "eslint": "^2.10.2",
-    "espower-babel": "^3.3.0",
-    "jscs": "^3.0.3",
-    "mocha": "^2.3.3",
-    "power-assert": "^1.1.0",
-    "textlint": "^6.8.0",
-    "textlint-rule-ignore-comments": "^1.1.0",
-    "textlint-rule-no-todo": "^2.0.0"
+    "babel-cli": "^6.24.1",
+    "babel-preset-env": "^1.4.0",
+    "babel-preset-power-assert": "^1.0.0",
+    "babel-register": "^6.24.1",
+    "eslint": "^6.0.1",
+    "babel-plugin-espower": "^3.0.1",
+    "mocha": "^6.1.4",
+    "power-assert": "^1.6.1",
+    "@textlint/kernel": "^3.1.6",
+    "textlint": "^11.2.6",
+    "textlint-filter-rule-comments": "^1.2.2",
+    "textlint-rule-no-todo": "^2.0.1"
   },
   "dependencies": {
-    "textlint-ast-test": "^1.1.2",
-    "txt-ast-traverse": "^1.2.1"
+    "@textlint/ast-tester": "^2.1.3",
+    "@textlint/ast-traverse": "^2.1.3"
   }
 }

--- a/src/review-to-ast.js
+++ b/src/review-to-ast.js
@@ -1,8 +1,8 @@
 // LICENSE : MIT
 'use strict';
 import assert from 'assert';
-import { traverse } from 'txt-ast-traverse';
-import { test as testTextlintAST } from 'textlint-ast-test';
+import { traverse } from '@textlint/ast-traverse';
+import { test as testTextlintAST } from '@textlint/ast-tester';
 import { Syntax } from './mapping';
 import { parseAsChunks } from './chunker';
 import { ChunkParsers } from './chunk-parsers';

--- a/test/ReVIEWProcessor-test.js
+++ b/test/ReVIEWProcessor-test.js
@@ -1,43 +1,50 @@
 // LICENSE : MIT
 'use strict';
 import assert from 'power-assert';
-import ReVIEWProcessor from '../src/ReVIEWProcessor';
-import { TextLintCore } from 'textlint';
+import ReVIEWPlugin from '../src/index';
+import { TextlintKernel } from "@textlint/kernel";
+import fs from "fs";
 import path from 'path';
 
-describe('ReVIEWProcessor', function () {
-  describe('ReVIEWPlugin', function () {
-    let textlint;
-    context('when target file is a ReVIEW', function () {
-      beforeEach(function () {
-        textlint = new TextLintCore();
-        textlint.addProcessor(ReVIEWProcessor);
+const lintFile = (filePath, filterRules, options = true) => {
+    const kernel = new TextlintKernel();
+    const text = fs.readFileSync(filePath, "utf-8");
+    return kernel.lintText(text, {
+        filePath,
+        ext: ".re",
+        plugins: [
+            {
+                pluginId: "review",
+                plugin: ReVIEWPlugin,
+                options
+            }
+        ],
+        rules: [
+          { ruleId: "no-todo", rule: require("textlint-rule-no-todo").default }
+        ],
+        filterRules: filterRules
+    });
+};
+
+describe('ReVIEWPlugin', function () {
+  context('when target file is a ReVIEW', function () {
+    it('should report error', function () {
+      const fixturePath = path.join(__dirname, '/fixtures/test.re');
+      return lintFile(fixturePath, []).then(results => {
+        assert(results.messages.length === 1);
+        assert(results.messages[0].line === 11);
+        assert(results.filePath === fixturePath);
       });
+    });
 
-      it('should report error', function () {
-        textlint.setupRules({
-          'no-todo': require('textlint-rule-no-todo'),
-        });
-
-        const fixturePath = path.join(__dirname, '/fixtures/test.re');
-        return textlint.lintFile(fixturePath).then(results => {
-          assert(results.messages.length === 1);
-          assert(results.messages[0].line === 10);
-          assert(results.filePath === fixturePath);
-        });
-      });
-
-      it('should not report error inside magic comments', function () {
-        textlint.setupRules({
-          'no-todo': require('textlint-rule-no-todo'),
-          'ignore-comments': require('textlint-rule-ignore-comments'),
-        });
-
-        const fixturePath = path.join(__dirname, '/fixtures/test.re');
-        return textlint.lintFile(fixturePath).then(results => {
-          assert(results.messages.length === 0);
-          assert(results.filePath === fixturePath);
-        });
+    it('should not report error inside magic comments', function () {
+      const fixturePath = path.join(__dirname, '/fixtures/test.re');
+      const filterRules = [
+        { ruleId: "filter", rule: require("textlint-filter-rule-comments") }
+      ];
+      return lintFile(fixturePath, filterRules).then(results => {
+        assert(results.messages.length === 0);
+        assert(results.filePath === fixturePath);
       });
     });
   });

--- a/test/compliance-test.js
+++ b/test/compliance-test.js
@@ -1,6 +1,6 @@
 // LICENSE : MIT
 'use strict';
-import { isTxtAST } from 'textlint-ast-test';
+import { isTxtAST } from '@textlint/ast-tester';
 import { parse } from '../src/review-to-ast';
 import assert from 'power-assert';
 import fs from 'fs';

--- a/test/fixtures/test.re
+++ b/test/fixtures/test.re
@@ -7,7 +7,9 @@ This is a sample document of Re:VIEW.
 =={about} About
 
 #@# textlint-disable no-todo
+
 TODO: This is TODO
+
 #@# textlint-enable no-todo
 
 Consecutive lines

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,1 @@
---compilers js:espower-babel/guess
+--require babel-register


### PR DESCRIPTION
display warning when install `textlint-plugin-review`:

```
$ npm install textlint-plugin-review
npm WARN deprecated textlint-ast-test@1.1.4: See https://github.com/textlint/textlint/issues/455
npm WARN deprecated txt-ast-traverse@1.2.1: See https://github.com/textlint/textlint/issues/455
npm WARN saveError ENOENT: no such file or directory, open '/Users/nobutada.matsubara/git/haskell/git-plantation/package.json'
npm WARN enoent ENOENT: no such file or directory, open '/Users/nobutada.matsubara/git/haskell/git-plantation/package.json'
npm WARN git-plantation No description
npm WARN git-plantation No repository field.
npm WARN git-plantation No README data
npm WARN git-plantation No license field.

+ textlint-plugin-review@0.3.3
added 3 packages from 2 contributors and audited 3 packages in 1.393s
found 0 vulnerabilities
```

Because, I fixed it to refer [`textlint-plugin-markdown`](https://github.com/textlint/textlint/tree/996b8059fc2e217ad2f5735688055fd520e872a8/packages/%40textlint/textlint-plugin-markdown)